### PR TITLE
DHFPROD-4723: Fixing how schemas databases are cleared

### DIFF
--- a/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/AbstractHubTest.java
+++ b/marklogic-data-hub/src/testFixtures/java/com/marklogic/hub/test/AbstractHubTest.java
@@ -106,17 +106,29 @@ public abstract class AbstractHubTest extends TestObject {
     protected void resetDatabases() {
         // Admin is needed to clear out provenance data
         runAsAdmin();
-        String xquery = "cts:uris((), (), cts:not-query(cts:collection-query('hub-core-artifact'))) ! xdmp:document-delete(.)";
-        HubClient hubClient = getHubClient();
-        // Running these with primitive retry support, as if a connection cannot be made to ML, this is typically the
-        // first thing that will fail
-        retryIfNecessary(() -> hubClient.getStagingClient().newServerEval().xquery(xquery).evalAs(String.class));
-        retryIfNecessary(() -> hubClient.getFinalClient().newServerEval().xquery(xquery).evalAs(String.class));
-        retryIfNecessary(() -> hubClient.getJobsClient().newServerEval().xquery(xquery).evalAs(String.class));
 
-        DatabaseManager databaseManager = new DatabaseManager(hubClient.getManageClient());
-        databaseManager.clearDatabase(hubClient.getDbName(DatabaseKind.STAGING_SCHEMAS));
-        databaseManager.clearDatabase(hubClient.getDbName(DatabaseKind.FINAL_SCHEMAS));
+        HubClient hubClient = getHubClient();
+        // Running these with primitive retry support, as if a connection cannot be made to ML, this is typically the first thing that will fail
+        clearDatabase(hubClient.getStagingClient());
+        clearDatabase(hubClient.getFinalClient());
+        clearDatabase(hubClient.getJobsClient());
+
+        try {
+            clearDatabase(getHubConfig().newStagingClient(getHubConfig().getDbName(DatabaseKind.STAGING_SCHEMAS)));
+        } catch (Exception ex) {
+            logger.warn("Unable to clear staging schemas database, but will continue: " + ex.getMessage());
+        }
+        try {
+            clearDatabase(getHubConfig().newStagingClient(getHubConfig().getDbName(DatabaseKind.FINAL_SCHEMAS)));
+        } catch (Exception ex) {
+            logger.warn("Unable to clear final schemas database, but will continue: " + ex.getMessage());
+        }
+    }
+
+    private void clearDatabase(DatabaseClient client) {
+        retryIfNecessary(() -> client.newServerEval()
+            .xquery("cts:uris((), (), cts:not-query(cts:collection-query('hub-core-artifact'))) ! xdmp:document-delete(.)")
+            .evalAs(String.class));
     }
 
     /**


### PR DESCRIPTION
Not sure why, but clearDatabase is failing against Docker VMs - so using a DatabaseClient again.

### Description

#### Checklist: 
```diff
- Note: do not change the below
```

-  ##### Owner:

- [ ] JIRA_ID included in all the commit messages
- [ ] PR title is in the format JIRA_ID:Title
- [ ] Rebase the branch with upstream
- [ ] Squashed all commits into a single commit
- [ ] Added Tests
  

- ##### Reviewer:

- [ ] Reviewed Tests
- [ ] Has good error handling and messaging
